### PR TITLE
[DECKS-646] Removing "wait-for-sync" mechanism from SimpleCloudStore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,14 +15,12 @@ let package =
       ),
     ],
     dependencies: [
-      .package(name: "SwiftConcurrency", url: "https://github.com/xiiagency/SwiftConcurrency", .branchItem("main")),
       .package(name: "SwiftFoundationExtensions", url: "https://github.com/xiiagency/SwiftFoundationExtensions", .branchItem("main")),
     ],
     targets: [
       .target(
         name: "SwiftSimpleCloudStore",
         dependencies: [
-          "SwiftConcurrency",
           "SwiftFoundationExtensions",
         ]
       ),

--- a/Sources/SwiftSimpleCloudStore/EnvironmentValues+Extensions.swift
+++ b/Sources/SwiftSimpleCloudStore/EnvironmentValues+Extensions.swift
@@ -42,7 +42,7 @@ public struct StaticSimpleCloudStoreProvider : SimpleCloudStoreProvider {
  */
 private struct SimpleCloudStoreProviderKey : EnvironmentKey {
   /**
-   Uses an instance of `UnknownSimpleCloudStoreProvider` as the default value.
+   Uses an instance of `UnavailableSimpleCloudStoreProvider` as the default value.
    */
   static let defaultValue: SimpleCloudStoreProvider = UnavailableSimpleCloudStoreProvider()
 }


### PR DESCRIPTION
Changes in the latest versions of iOS mean that the underlying key-value store is ready at all start up. No followup "initial sync" notifications are sent by the OS and waiting for it is useless now.

Works on xiiagency/Decks#646